### PR TITLE
Fix hot module replacement

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ var plugins = [
 ];
 
 if (!isProduction) {
-  plugins.push(new webpack.HotModuleReplacementPlugin()),
   plugins.push(new webpack.NoErrorsPlugin())
 }
 


### PR DESCRIPTION
Remove duplicate hot module replacement plugin when using `--hot` as argument to `webpack-dev-server`
